### PR TITLE
[Refactor] Feature #week2

### DIFF
--- a/2Week_Mission/.gitignore
+++ b/2Week_Mission/.gitignore
@@ -38,3 +38,4 @@ out/
 
 application-dev.yml
 application-test.yml
+application-base-addi.yml

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/base/initData/NotProdInitData.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/base/initData/NotProdInitData.java
@@ -97,7 +97,7 @@ public class NotProdInitData {
             memberService.addCash(member1, 10_000, "충전__무통장입금");
             memberService.addCash(member1, 20_000, "충전__무통장입금");
             memberService.addCash(member1, -5_000, "출금__일반");
-//            memberService.addCash(member1, 1_000_000, "충전__무통장입금");
+            memberService.addCash(member1, 1_000_000, "충전__무통장입금");
 //
 //            memberService.addCash(member2, 2_000_000, "충전__무통장입금");
 

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/base/initData/NotProdInitData.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/base/initData/NotProdInitData.java
@@ -97,9 +97,9 @@ public class NotProdInitData {
             memberService.addCash(member1, 10_000, "충전__무통장입금");
             memberService.addCash(member1, 20_000, "충전__무통장입금");
             memberService.addCash(member1, -5_000, "출금__일반");
-            memberService.addCash(member1, 1_000_000, "충전__무통장입금");
-
-            memberService.addCash(member2, 2_000_000, "충전__무통장입금");
+//            memberService.addCash(member1, 1_000_000, "충전__무통장입금");
+//
+//            memberService.addCash(member2, 2_000_000, "충전__무통장입금");
 
             /*
             // 주문 생성 데이터

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/base/rq/Rq.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/base/rq/Rq.java
@@ -90,6 +90,10 @@ public class Rq {
         return Ut.url.encode(msg) + ";ttl=" + new Date().getTime();
     }
 
+    public static String redirectWithErrorMsg(String url, String errorMsg) {
+        return "redirect:" + urlWithErrorMsg(url, errorMsg);
+    }
+
     public String redirectWithErrorMsg(String url, RsData rsData) {
         url = Ut.url.modifyQueryParam(url, "errorMsg", msgWithTtl(rsData.getMsg()));
 

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/controller/CartController.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/controller/CartController.java
@@ -74,6 +74,6 @@ public class CartController {
                     }
                 });
 
-        return "redirect:/cart/list?msg=" + Ut.url.encode("%d건의 품목을 삭제하였습니다.".formatted(idsArr.length));
+        return Rq.redirectWithMsg("/cart/list", "%d건의 품목을 삭제하였습니다.".formatted(idsArr.length));
     }
 }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/controller/CartController.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/controller/CartController.java
@@ -40,7 +40,7 @@ public class CartController {
         return "cart/list";
     }
 
-    @GetMapping("/add/{id}")
+    @PostMapping("/add/{id}")
     @PreAuthorize("isAuthenticated()")
     public String addItems(@PathVariable Long id, @AuthenticationPrincipal MemberContext memberContext, Model model) {
         Member buyer = memberContext.getMember();
@@ -52,7 +52,7 @@ public class CartController {
 
         CartItem addItem = cartService.addItem(buyer, wantedItem);
 
-        model.addAttribute("items", addItem);
+//        model.addAttribute("items", addItem);
 
         return Rq.redirectWithMsg("/cart/list", "%s이 장바구니에 담겼습니다.".formatted(wantedItem.getSubject()));
     }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/controller/CartController.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/controller/CartController.java
@@ -46,8 +46,8 @@ public class CartController {
         Member buyer = memberContext.getMember();
         Product wantedItem = productService.findById(id).get();
 
-        if(cartService.hasItem(buyer, wantedItem)){
-            return "redirect:/product/"+id+"?errorMsg=" + Ut.url.encode("이미 장바구니에 담은 상품입니다.");
+        if(cartService.hasItem(wantedItem)){
+            return Rq.redirectWithErrorMsg("/product/"+id, "이미 장바구니에 담은 상품입니다.");
         }
 
         CartItem addItem = cartService.addItem(buyer, wantedItem);

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/repository/CartItemRepository.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/repository/CartItemRepository.java
@@ -12,4 +12,6 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     boolean existsByBuyerIdAndProductId(long buyerId, long productId);
 
     List<CartItem> findAllByBuyerId(long buyerId);
+
+    Optional<CartItem> findByProductId(Long productId);
 }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/service/CartService.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/service/CartService.java
@@ -52,15 +52,6 @@ public class CartService {
         cartItemRepository.delete(cartItem);
     }
 
-    @Transactional
-    public void removeItem(
-            Member buyer,
-            Long productId
-    ) {
-        Product product = new Product(productId);
-        removeItem(buyer, product.getId());
-    }
-
     public boolean actorCanDelete(Member buyer, CartItem cartItem) {
         return buyer.getId().equals(cartItem.getBuyer().getId());
     }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/service/CartService.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/cart/service/CartService.java
@@ -43,8 +43,15 @@ public class CartService {
         return cartItemRepository.findById(id);
     }
 
-    public boolean hasItem(Member buyer, Product wantedItem) {
-        return cartItemRepository.existsByBuyerIdAndProductId(buyer.getId(), wantedItem.getId());
+    public boolean hasItem(Product wantedItem) {
+        CartItem cartItem = cartItemRepository.findByProductId(wantedItem.getId()).orElse(null);
+
+        if (cartItem == null) {
+            return false;
+        }
+        else {
+            return true;
+        }
     }
 
     @Transactional

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/mybook/entity/MyBook.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/mybook/entity/MyBook.java
@@ -1,0 +1,32 @@
+package com.ll.exam.final__2022_10_08.app.mybook.entity;
+
+import com.ll.exam.final__2022_10_08.app.base.entity.BaseEntity;
+import com.ll.exam.final__2022_10_08.app.member.entity.Member;
+import com.ll.exam.final__2022_10_08.app.order.entity.OrderItem;
+import com.ll.exam.final__2022_10_08.app.product.entity.Product;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class MyBook extends BaseEntity {
+    @ManyToOne(fetch = LAZY)
+    @ToString.Exclude
+    private Member buyer;
+
+    @ManyToOne(fetch = LAZY)
+    @ToString.Exclude
+    private Product product;
+}

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/mybook/repository/MyBookRepository.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/mybook/repository/MyBookRepository.java
@@ -1,0 +1,7 @@
+package com.ll.exam.final__2022_10_08.app.mybook.repository;
+
+import com.ll.exam.final__2022_10_08.app.mybook.entity.MyBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MyBookRepository extends JpaRepository<MyBook, Long> {
+}

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/mybook/service/MyBookService.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/mybook/service/MyBookService.java
@@ -1,0 +1,37 @@
+package com.ll.exam.final__2022_10_08.app.mybook.service;
+
+import com.ll.exam.final__2022_10_08.app.member.entity.Member;
+import com.ll.exam.final__2022_10_08.app.mybook.entity.MyBook;
+import com.ll.exam.final__2022_10_08.app.mybook.repository.MyBookRepository;
+import com.ll.exam.final__2022_10_08.app.order.entity.OrderItem;
+import com.ll.exam.final__2022_10_08.app.product.entity.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyBookService {
+    private final MyBookRepository myBookRepository;
+
+    @Transactional
+    public void addItems(Member buyer, List<OrderItem> orderItems) {
+        for (OrderItem orderItem : orderItems) {
+            saveItems(buyer, orderItem.getProduct());
+        }
+    }
+
+    @Transactional
+    public void saveItems(Member buyer, Product product) {
+        MyBook myBook = MyBook
+                .builder()
+                .buyer(buyer)
+                .product(product)
+                .build();
+
+        myBookRepository.save(myBook);
+    }
+}

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/controller/OrderController.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/controller/OrderController.java
@@ -13,6 +13,7 @@ import com.ll.exam.final__2022_10_08.app.order.service.OrderService;
 import com.ll.exam.final__2022_10_08.app.security.dto.MemberContext;
 import com.ll.exam.final__2022_10_08.util.Ut;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -108,7 +109,8 @@ public class OrderController {
         });
     }
 
-    private final String SECRET_KEY = "test_sk_YyZqmkKeP8goN04j1xj8bQRxB9lG";
+    @Value("${custom.toss.serverKey}")
+    private String SECRET_KEY;
 
     @RequestMapping("/{id}/success")
     public String confirmPayment(

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/controller/OrderController.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/controller/OrderController.java
@@ -193,4 +193,22 @@ public class OrderController {
 
         return Rq.redirectWithMsg("/order/%d?msg=".formatted(order.getId()), "예치금으로 결제했습니다.");
     }
+
+    /**
+     * 주문 취소
+     */
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize("isAuthenticated()")
+    public String cancelOrder(@PathVariable Long id, @AuthenticationPrincipal MemberContext memberContext) {
+        Member member = memberContext.getMember();
+        Order order = orderService.findForPrintById(id).get();
+
+        if (orderService.actorCanSee(member, order) == false) {
+            throw new ActorCanNotSeeOrderException();
+        }
+
+        orderService.cancelOrder(order);
+
+        return Rq.redirectWithMsg("/cart/list","%d번 주문이 취소되었습니다.".formatted(order.getId()));
+    }
 }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/controller/OrderController.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.ll.exam.final__2022_10_08.app.order.controller;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ll.exam.final__2022_10_08.app.base.rq.Rq;
 import com.ll.exam.final__2022_10_08.app.member.entity.Member;
 import com.ll.exam.final__2022_10_08.app.member.service.MemberService;
 import com.ll.exam.final__2022_10_08.app.order.entity.Order;
@@ -190,6 +191,6 @@ public class OrderController {
 
         orderService.payByRestCashOnly(order);
 
-        return "redirect:/order/%d?msg=%s".formatted(order.getId(), Ut.url.encode("예치금으로 결제했습니다."));
+        return Rq.redirectWithMsg("/order/%d?msg=".formatted(order.getId()), "예치금으로 결제했습니다.");
     }
 }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/entity/Order.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/entity/Order.java
@@ -87,11 +87,10 @@ public class Order extends BaseEntity {
         this.name = name;
     }
 
-    // 사용되지 않는 메서드 ??
-//    public boolean isPayable() {
-//        if ( isPaid ) return false;
-//        if ( isCanceled ) return false;
-//
-//        return true;
-//    }
+    public boolean isPayable() {
+        if ( isPaid ) return false;
+        if ( isCanceled ) return false;
+
+        return true;
+    }
 }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/entity/Order.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/entity/Order.java
@@ -81,16 +81,17 @@ public class Order extends BaseEntity {
         String name = orderItems.get(0).getProduct().getSubject();
 
         if (orderItems.size() > 1) {
-            name += " 외 %d곡".formatted(orderItems.size() - 1);
+            name += " 외 %d권".formatted(orderItems.size() - 1);
         }
 
         this.name = name;
     }
 
-    public boolean isPayable() {
-        if ( isPaid ) return false;
-        if ( isCanceled ) return false;
-
-        return true;
-    }
+    // 사용되지 않는 메서드 ??
+//    public boolean isPayable() {
+//        if ( isPaid ) return false;
+//        if ( isCanceled ) return false;
+//
+//        return true;
+//    }
 }

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/service/OrderService.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/service/OrderService.java
@@ -4,6 +4,7 @@ import com.ll.exam.final__2022_10_08.app.cart.entity.CartItem;
 import com.ll.exam.final__2022_10_08.app.cart.service.CartService;
 import com.ll.exam.final__2022_10_08.app.member.entity.Member;
 import com.ll.exam.final__2022_10_08.app.member.service.MemberService;
+import com.ll.exam.final__2022_10_08.app.mybook.service.MyBookService;
 import com.ll.exam.final__2022_10_08.app.order.entity.Order;
 import com.ll.exam.final__2022_10_08.app.order.entity.OrderItem;
 import com.ll.exam.final__2022_10_08.app.order.repository.OrderRepository;
@@ -23,6 +24,7 @@ public class OrderService {
     private final MemberService memberService;
     private final CartService cartService;
     private final OrderRepository orderRepository;
+    private final MyBookService myBookService;
 
     @Transactional
     public Order createFromCart(Member buyer) {
@@ -82,6 +84,7 @@ public class OrderService {
         memberService.addCash(buyer, payPrice * -1, "주문__%d__사용__예치금".formatted(order.getId()));
 
         order.setPaymentDone();
+        myBookService.addItems(buyer, order.getOrderItems());
         orderRepository.save(order);
     }
 
@@ -121,6 +124,7 @@ public class OrderService {
         }
 
         order.setPaymentDone();
+        myBookService.addItems(buyer, order.getOrderItems());
         orderRepository.save(order);
     }
 

--- a/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/service/OrderService.java
+++ b/2Week_Mission/src/main/java/com/ll/exam/final__2022_10_08/app/order/service/OrderService.java
@@ -135,4 +135,9 @@ public class OrderService {
     public List<Order> getOrderList(Member buyer) {
         return orderRepository.findAllByBuyerId(buyer.getId());
     }
+
+    @Transactional
+    public void cancelOrder(Order order) {
+        orderRepository.delete(order);
+    }
 }

--- a/2Week_Mission/src/main/resources/application-base-addi.yml.default
+++ b/2Week_Mission/src/main/resources/application-base-addi.yml.default
@@ -1,3 +1,0 @@
-spring:
-  mail:
-    password: NEED_TO_INPUT_GMAIL_APP_PASSWORD

--- a/2Week_Mission/src/main/resources/application.yml
+++ b/2Week_Mission/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
     host: smtp.gmail.com
     port: 587
     username: aimee3322@gmail.com
-    password: NEED_TO_EMPTY
+    password:
     properties:
       mail:
         smtp:

--- a/2Week_Mission/src/main/resources/templates/cart/list.html
+++ b/2Week_Mission/src/main/resources/templates/cart/list.html
@@ -96,7 +96,7 @@
         </li>
       </ul>
 
-      <a href="javascript:;" onclick="RemoveCartItemsForm__submit();" class="btn btn-warning btn-outline btn-sm">선택삭제</a>
+      <a href="javascript:;" onclick="RemoveCartItemsForm__submit();" class="btn btn-info btn-sm">선택삭제</a>
       <form method="POST" name="removeCartItemsForm" th:action="@{|/cart/remove|}" hidden>
         <input type="hidden" name="ids">
       </form>

--- a/2Week_Mission/src/main/resources/templates/cart/list.html
+++ b/2Week_Mission/src/main/resources/templates/cart/list.html
@@ -77,23 +77,23 @@
             </div>
           </div>
         </li>
-        <li th:each="item : ${addItem}" class="flex items-center m-2 p-2">
-          <input onchange="CartItemCheckbox__changed();" type="checkbox" class="cartItemCheckbox checkbox mr-2" th:value="${item.id}">
-          <svg width="80" height="80" th:data-jdenticon-value="${item.product.jdenticon}"></svg>
-          <div class="ml-2">
-            <div>
-              <span>상품명 : </span><span th:text="${item.product.subject}"></span>
-            </div>
-            <div>
-              <span>작가명 : </span><span th:text="${item.product.author.name}"></span>
-            </div>
-            <div>
-              <span>가격 : </span><span th:text="${item.product.salePrice}"></span>
-            </div>
-          </div>
+<!--        <li th:each="item : ${addItem}" class="flex items-center m-2 p-2">-->
+<!--          <input onchange="CartItemCheckbox__changed();" type="checkbox" class="cartItemCheckbox checkbox mr-2" th:value="${item.id}">-->
+<!--          <svg width="80" height="80" th:data-jdenticon-value="${item.product.jdenticon}"></svg>-->
+<!--          <div class="ml-2">-->
+<!--            <div>-->
+<!--              <span>상품명 : </span><span th:text="${item.product.subject}"></span>-->
+<!--            </div>-->
+<!--            <div>-->
+<!--              <span>작가명 : </span><span th:text="${item.product.author.name}"></span>-->
+<!--            </div>-->
+<!--            <div>-->
+<!--              <span>가격 : </span><span th:text="${item.product.salePrice}"></span>-->
+<!--            </div>-->
+<!--          </div>-->
 
-          </span>
-        </li>
+<!--          </span>-->
+<!--        </li>-->
       </ul>
 
       <a href="javascript:;" onclick="RemoveCartItemsForm__submit();" class="btn btn-info btn-sm">선택삭제</a>

--- a/2Week_Mission/src/main/resources/templates/fragment/productListItem.html
+++ b/2Week_Mission/src/main/resources/templates/fragment/productListItem.html
@@ -37,10 +37,10 @@
                 </div>
             </div>
             <div class="card-actions justify-end">
-                <a th:href="@{|/cart/add/${product.id}|}" class="btn btn-sm">
+                <form method="POST" th:action="@{|/cart/add/${product.id}|}" class="btn btn-sm">
                     <i class="fa-solid fa-cart-plus"></i>
-                    <span class="ml-2">장바구니</span>
-                </a>
+                    <button class="ml-2">장바구니</button>
+                </form>
 
                 <a th:href="@{|/product/${product.id}|}" class="btn btn-sm">
                     <i class="fa-solid fa-eye"></i>

--- a/2Week_Mission/src/main/resources/templates/order/detail.html
+++ b/2Week_Mission/src/main/resources/templates/order/detail.html
@@ -71,12 +71,18 @@
                                    type="checkbox" class="ml-2 checkbox">
                         </label>
                     </div>
-                    <button th:if="${order.payable}" onclick="payment();" class="btn btn-sm btn-primary">카드결제</button>
-                    <span th:if="${order.isPaid}">결제완료</span>
+                    <div class="my-3 flex gap-2">
+                        <form method="POST" th:action="@{|/order/${order.id}/cancel|}" class="inline-flex">
+                            <button onclick="return confirm('주문을 취소하시겠습니까?')" class="btn btn-sm btn-info">주문 취소</button>
+                        </form>
+
+                        <button th:if="${order.payable}" onclick="payment();" class="btn btn-sm btn-primary inline-flex">카드결제</button>
+                        <span th:if="${order.isPaid}">결제완료</span>
+                    </div>
                 </div>
                 <div>
                     <div>
-                        <span>PG결제가격 : </span>
+                        <span class="text-primary">PG결제가격 : </span>
                         <span id="PaymentForm__pgPayPriceDisplay">
 
                         </span>

--- a/2Week_Mission/src/main/resources/templates/order/detail.html
+++ b/2Week_Mission/src/main/resources/templates/order/detail.html
@@ -91,7 +91,7 @@
         const $PaymentForm__useRestCashAll = $("#PaymentForm__useRestCashAll");
         const $PaymentForm__pgPayPriceDisplay = $("#PaymentForm__pgPayPriceDisplay");
 
-        const tossPayments = TossPayments("test_ck_BE92LAa5PVbDMxDgLzB87YmpXyJj");
+        const tossPayments = TossPayments("test_ck_JQbgMGZzorzRn0Qy0D7rl5E1em4d");
 
         function payment() {
             let useRestCash = parseInt($PaymentForm__useRestCash.val());

--- a/2Week_Mission/src/main/resources/templates/order/list.html
+++ b/2Week_Mission/src/main/resources/templates/order/list.html
@@ -18,22 +18,22 @@
                 <thead class="table-dark">
                 <tr>
                     <th>주문번호</th>
+                    <th>주문상품</th>
                     <th>주문날짜</th>
                     <th>주문가격</th>
-                    <th>주문상품</th>
                 </tr>
                 </thead>
 
                 <tbody>
                 <tr th:each="order : ${orders}">
                     <td th:text="${order.id}"></td>
-                    <td th:text="${#temporals.format(order.modifyDate, 'yy-MM-dd HH:mm')}"></td>
-                    <td th:text="${order.calculatePayPrice}"></td>
                     <td th:each="orderItem : ${order.orderItems}">
                         <a th:href="@{/order/{id}(id = ${order.id})}">
-                        <span th:text="${orderItem.product.subject}" th:id="${order.id}" class="text-primary"></span>
+                            <span th:text="${orderItem.product.subject}" th:id="${order.id}" class="text-primary"></span>
                         </a>
                     </td>
+                    <td th:text="${#temporals.format(order.modifyDate, 'yy-MM-dd HH:mm')}"></td>
+                    <td th:text="${order.calculatePayPrice}"></td>
                 </tr>
                 </tbody>
 


### PR DESCRIPTION
### 2주차 리팩토링

---

- [x]  불필요한 메서드 정리, 용어 수정
- [x]  토스 테스트 시크릿키 숨김처리 (`application-base-addi.yml`)

    - 아래의 자료들 참고

    [[Spring properties 사용시 UnsatisfiedDependencyException: Could not resolve placeholder 오류 조치](https://oingdaddy.tistory.com/235)](https://oingdaddy.tistory.com/235)
    
    [[Springboot application.yml 파일의 값 가져오기 (feat. @Value is null)](https://oingdaddy.tistory.com/186)](https://oingdaddy.tistory.com/186)
    
- [x]  CartController에 url 리다이렉트 Rq 사용으로 통일
- [x]  OrderController에 url 리다이렉트 Rq 사용으로 변경
- [x]  결제 완료 이후 `MyBook` 테이블에 구매한 책 추가됨
    
    <img width="1330" alt="스크린샷 2022-10-28 오전 3 06 43" src="https://user-images.githubusercontent.com/62376361/198474726-5a962a7d-770c-4228-a21d-d3748ebe94a7.png">

- [x]  주문 취소 기능 : 주문 생성 이후 → 주문은 준비상태 → 주문 준비상태에서 `주문 취소`
- [x]  장바구니 안 담겨있는 도서일 경우 매번 장바구니에 담을 때마다 쿼리 문이 두 번 돌아가게됨 
(이미 장바구니 담겨 있는지 쿼리문 + 장바구니 추가하는 쿼리문)
    
    해결 : `cartService.hasItem` 리팩토링하기
    
     `hasItem()`에서 `findByProudctId`를 통해 이미 담은 장바구니 목록이라면 `null` 로 받아와서 처리 
    → 장바구니에 담을 때 쿼리문이 한번만 실행되게 된다.
    
- [x]  Rq에 있는 url 리다이렉트 errorMsg 사용하는 메서드 하나 구현
- [x]  장바구니 담기 처리 `Get` → `Post` 방식으로 변경
- [ ]  예외 클래스들 enum 으로 관리 (추후 시도 예정)